### PR TITLE
Patch v0.3.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpesa"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Collins Muriuki <murerwacollins@gmail.com>"]
 edition = "2018"
 description = "A wrapper around the M-PESA API in Rust."

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ An unofficial Rust wrapper around the [Safaricom API](https://developer.safarico
 
 ```md
 [dependencies]
-mpesa = "0.3.4"
+mpesa = "0.3.5"
 ```
 
 In your lib or binary crate:

--- a/src/client.rs
+++ b/src/client.rs
@@ -92,7 +92,7 @@ impl<'a> Mpesa {
     ///
     /// # Errors
     /// Returns a `MpesaError` on failure
-    pub fn auth(&self) -> MpesaResult<String> {
+    pub(crate) fn auth(&self) -> MpesaResult<String> {
         let url = format!(
             "{}/oauth/v1/generate?grant_type=client_credentials",
             self.environment.base_url()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```md
 //! [dependencies]
-//! mpesa = "0.3.4"
+//! mpesa = "0.3.5"
 //! ```
 //!
 //! In your lib or binary crate:


### PR DESCRIPTION
## Changelog
- Make `Mpesa` client `auth` method only public within the context of the crate