### PR TITLE
v1.0.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "mpesa"
-version = "0.4.2"
+version = "1.0.0"
 authors = ["Collins Muriuki <murerwacollins@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "A wrapper around the M-PESA API in Rust."
 keywords = ["api", "mpesa", "mobile"]
 repository = "https://github.com/collinsmuriuki/mpesa-rust"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An unofficial Rust wrapper around the [Safaricom API](https://developer.safarico
 
 ```toml
 [dependencies]
-mpesa = { git = "https://github.com/collinsmuriuki/mpesa-rust" }
+mpesa = { version = "1.0.0" }
 ```
 
 Optionally, you can disable default-features, which is basically the entire suite of MPESA APIs to conditionally select from either:
@@ -33,7 +33,7 @@ Example:
 
 ```toml
 [dependencies]
-mpesa = { git = "https://github.com/collinsmuriuki/mpesa-rust", default_features = false, features = ["b2b", "express_request"] }
+mpesa = { git = "1.0.0", default_features = false, features = ["b2b", "express_request"] }
 ```
 
 In your lib or binary crate:


### PR DESCRIPTION
On merge, will push v1.0.0 tag to initiate release to crates.io