### PR TITLE
Mask client secret and initiator password in debug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT"
 chrono = {version = "0.4", optional = true, default-features = false, features = ["clock", "serde"] }
 openssl = {version = "0.10", optional = true}
 reqwest = {version = "0.11", features = ["json"]}
+secrecy = "0.8.0"
 serde = {version="1.0", features= ["derive"]}
 serde_json = "1.0"
 serde_repr = "0.1"
@@ -25,17 +26,7 @@ tokio = {version = "1", features = ["rt", "rt-multi-thread", "macros"]}
 wiremock = "0.5"
 
 [features]
-default = [
-	"account_balance",
-	"b2b",
-	"b2c",
-	"bill_manager",
-	"c2b_register",
-	"c2b_simulate",
-	"express_request",
-	"transaction_reversal",
-	"transaction_status"
-]
+default = ["account_balance", "b2b", "b2c", "bill_manager", "c2b_register", "c2b_simulate", "express_request", "transaction_reversal", "transaction_status"]
 account_balance = ["dep:openssl"]
 b2b = ["dep:openssl"]
 b2c = ["dep:openssl"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -42,6 +42,9 @@ impl<'mpesa, Env: ApiEnvironment> Mpesa<Env> {
     ///     Environment::Sandbox,
     /// );
     /// ```
+    ///
+    /// # Panics
+    /// This method can panic if a TLS backend cannot be initialized for the internal http_client
     pub fn new<S: Into<String>>(client_key: S, client_secret: S, environment: Env) -> Self {
         let http_client = HttpClient::builder()
             .connect_timeout(std::time::Duration::from_millis(10_000))

--- a/src/client.rs
+++ b/src/client.rs
@@ -101,7 +101,6 @@ impl<'mpesa, Env: ApiEnvironment> Mpesa<Env> {
     ///
     /// # Errors
     /// Returns a `MpesaError` on failure
-    #[allow(clippy::single_char_pattern)]
     pub(crate) async fn auth(&self) -> MpesaResult<String> {
         let url = format!(
             "{}/oauth/v1/generate?grant_type=client_credentials",

--- a/src/client.rs
+++ b/src/client.rs
@@ -26,7 +26,7 @@ pub type MpesaResult<T> = Result<T, MpesaError>;
 pub struct Mpesa<Env: ApiEnvironment> {
     client_key: String,
     client_secret: Secret<String>,
-    initiator_password: RefCell<Option<String>>,
+    initiator_password: RefCell<Option<Secret<String>>>,
     pub(crate) environment: Env,
     pub(crate) http_client: HttpClient,
 }
@@ -65,7 +65,7 @@ impl<'mpesa, Env: ApiEnvironment> Mpesa<Env> {
         let Some(p) = &*self.initiator_password.borrow() else {
             return DEFAULT_INITIATOR_PASSWORD.to_owned();
         };
-        p.to_owned()
+        p.expose_secret().into()
     }
 
     /// Optional in development but required for production, you will need to call this method and set your production initiator password.
@@ -82,7 +82,7 @@ impl<'mpesa, Env: ApiEnvironment> Mpesa<Env> {
     /// client.set_initiator_password("your_initiator_password");
     /// ```
     pub fn set_initiator_password<S: Into<String>>(&self, initiator_password: S) {
-        *self.initiator_password.borrow_mut() = Some(initiator_password.into());
+        *self.initiator_password.borrow_mut() = Some(Secret::new(initiator_password.into()));
     }
 
     /// Checks if the client can be authenticated


### PR DESCRIPTION
Prevent client secret and initiator password visibility in `Mpesa` client debug